### PR TITLE
Patch lib.pbs to look for .exe extension (fixes pbs on windows)

### DIFF
--- a/lib/pbs.py
+++ b/lib/pbs.py
@@ -217,6 +217,9 @@ class RunningCommand(object):
     def __int__(self):
         return int(str(self).strip())
 
+    def exit_code(self):
+        return self.exit_code
+
     @property
     def stdout(self):
         if self.call_args["bg"]: self.wait()
@@ -234,6 +237,7 @@ class RunningCommand(object):
         return str(self)
 
     def _handle_exit_code(self, rc):
+        self.exit_code = rc
         if rc not in self.call_args["ok_code"]:
             raise get_rc_exc(rc)(self.command_ran, self._stdout, self._stderr)
 


### PR DESCRIPTION
With this patch, pbs is able to launch programs correctly on windows without specifying the .exe extension
