### PR TITLE
corePlugins.filter_download.RegEx wasn't honoring case-insensitivity

### DIFF
--- a/corePlugins/filter_download/RegEx.py
+++ b/corePlugins/filter_download/RegEx.py
@@ -57,9 +57,7 @@ class RegEx(DownloadFilter):
                 replacement = ''
             rawRegex = rawRegex.replace('{{' + fieldName + '}}', replacement)
 
-        pattern = re.compile(rawRegex)
-        if self.c.case_sensitive:
-            result = pattern.match(string)
-        else:
-            result = pattern.match(string, re.I)
+        pattern = re.compile(rawRegex) if self.c.case_sensitive else re.compile(rawRegex, re.I)
+        result = pattern.match(string)
+
         return self.FilterResult(bool(result) == bool(self.c.positive), string)


### PR DESCRIPTION
pattern.match doesn't accept flags as second arg. Fix it using flags in re.compile.
